### PR TITLE
feat(login): wire login page to real API with role-based redirect

### DIFF
--- a/frontend/app/login/page.jsx
+++ b/frontend/app/login/page.jsx
@@ -1,8 +1,11 @@
 'use client';
 
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import api from '@/lib/api';
 
 export default function LoginPage() {
+  const router = useRouter();
   const [form, setForm] = useState({ email: '', password: '' });
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
@@ -19,18 +22,25 @@ export default function LoginPage() {
       return;
     }
     setLoading(true);
-    // API call will be wired here in Phase 2
-    // For now simulate login
-    setTimeout(() => {
+    try {
+      const response = await api.post('/api/auth/login', {
+        email: form.email,
+        password: form.password,
+      });
+      localStorage.setItem('iqueue_token', response.data.token);
+      localStorage.setItem('iqueue_user', JSON.stringify(response.data.user));
+      const role = response.data.user.role;
+      if (role === 'customer')       router.push('/tracker');
+      else if (role === 'staff')     router.push('/staff');
+      else if (role === 'manager')   router.push('/dashboard');
+      else if (role === 'admin')     router.push('/admin');
+      else                           router.push('/tracker');
+    } catch (err) {
+      const message = err.response?.data?.message || 'Invalid email or password';
+      setError(message);
+    } finally {
       setLoading(false);
-      // Simulate wrong credentials for demo
-      if (form.password === 'wrong') {
-        setError('Invalid email or password');
-      } else {
-        console.log('Login successful:', form.email);
-        // Will redirect based on role in Phase 2
-      }
-    }, 1500);
+    }
   };
 
   return (


### PR DESCRIPTION
## What does this PR do?
Wires the login form to the real backend API.
Login now authenticates against MongoDB, saves JWT and 
user info to localStorage, and redirects by role.

## Type of change
- [x] New feature

## Files changed
- frontend/app/login/page.jsx — replaced fake setTimeout 
  with real API call and role-based redirect

## How to test this
1. Go to http://localhost:3000/login
2. Login with staff@iqueue.app / staff123456
3. Should redirect to /staff
4. Login with manager@iqueue.app / manager123456
5. Should redirect to /dashboard

## Checklist
- [x] Code runs without errors locally
- [x] No .env file committed
- [x] No node_modules committed

## Related Issue
Closes #41